### PR TITLE
Fix mac m1 error when executing mvn exec

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,11 @@
             <artifactId>jgrapht-core</artifactId>
             <version>1.0.1</version>
         </dependency>
+        <dependency>
+            <groupId>org.xerial.snappy</groupId>
+            <artifactId>snappy-java</artifactId>
+        <version>1.1.8.4</version>
+    </dependency>
     </dependencies>
     <build>
         <plugins>


### PR DESCRIPTION
- Fix mac M1 error
`java: org.xerial.snappy.SnappyError: [FAILED_TO_LOAD_NATIVE_LIBRARY] no native library is found for os.name=Mac and os.arch=aarch64`